### PR TITLE
Create groups based on user's groups.

### DIFF
--- a/canvasoauthenticator/__init__.py
+++ b/canvasoauthenticator/__init__.py
@@ -115,7 +115,7 @@ class CanvasOAuthenticator(GenericOAuthenticator):
 
     async def get_courses(self, token):
         """
-        Get list of courses enrolled by the current user
+        Get list of active courses for the current user.
 
         See https://canvas.instructure.com/doc/api/courses.html#method.courses.index
         """

--- a/canvasoauthenticator/__init__.py
+++ b/canvasoauthenticator/__init__.py
@@ -104,7 +104,7 @@ class CanvasOAuthenticator(GenericOAuthenticator):
             async with session.get(url, headers=headers, params=self.extra_params) as r:
                 if r.status != 200:
                     raise Exception(
-                        f"error fetching items for {self.username}: {url} -- {r.status} -- {r.text()}"
+                        f"error fetching items {url} -- {r.status} -- {r.text()}"
                     )
                 data = await r.json()
                 if "next" in r.links.keys():

--- a/canvasoauthenticator/__init__.py
+++ b/canvasoauthenticator/__init__.py
@@ -141,7 +141,7 @@ class CanvasOAuthenticator(GenericOAuthenticator):
         """
         Return a group name assembled from provided terms.
         """
-        return "::".join(map(str(terms)))
+        return "::".join(map(str, terms))
 
     def groups_from_canvas_courses(self, courses):
         """

--- a/canvasoauthenticator/__init__.py
+++ b/canvasoauthenticator/__init__.py
@@ -188,7 +188,7 @@ class CanvasOAuthenticator(GenericOAuthenticator):
             if "name" not in group:
                 continue
             name = group.get("name")
-            # `context_type` might be "Course" or "account"
+            # `context_type` might be "Course" or "Account"
             context_type = group.get("context_type").lower()
             # The corresponding id field, e.g. `course_id` or `account_id`
             context_id_field = context_type + "_id"


### PR DESCRIPTION
They are available as `course::{course_id}::group::{name}`. This also changes the format of course-based groups from `canvas::{course_id}::{enrollment_type}` to `course::{course_id}::enrollment_type::{enrollment_type}`.